### PR TITLE
upgrading php max file upload size to import studyarea from large files

### DIFF
--- a/docker/ltb/Dockerfile
+++ b/docker/ltb/Dockerfile
@@ -59,6 +59,10 @@ RUN printf "date.timezone = \"America/Chicago\"\n" >> `php -i | grep php.ini | a
 # Disable asserts
 RUN printf "zend.assertions = -1\n" >> `php -i | grep php.ini | awk '{print $6'}`/php.ini
 
+# Max File upload and form post size.
+printf "post_max_size = 10M\n" >> `php -i | grep php.ini | awk '{print $6'}`/php.ini
+printf "upload_max_filesize = 10M\n" >> `php -i | grep php.ini | awk '{print $6'}`/php.ini
+
 # Install PHP extensions
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install opcache


### PR DESCRIPTION
With this update, it is now possible to import studyarea from file of max 10M